### PR TITLE
fix(build) SendNotification is not a member of WorldSession

### DIFF
--- a/src/mod_congratsonlevel.cpp
+++ b/src/mod_congratsonlevel.cpp
@@ -301,7 +301,7 @@ public:
                     default:
                         break;
                 }
-                player->GetSession()->SendNotification(SERVER_MSG_STRING, ss2.str().c_str());
+                ChatHandler(player->GetSession()).SendNotification(SERVER_MSG_STRING, ss2.str().c_str());
                 return;
             }
         }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Fix the error that occurs when compiling the module in the latest version of the emulator.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/mod-congrats-on-level/issues/34

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Windows 10

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. Download the changes in the pull request
2. Build and test in-game.